### PR TITLE
Github: Add Play Store publication to actions

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -12,5 +12,18 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
+      - uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Setup Android problem matchers
+        uses: jonasb/android-problem-matchers-action@v1
       - name: Build with Gradle
         run: ./gradlew build
+      - name: Publish to Play Store
+        if: github.ref == 'master'
+        run: |
+          ./scripts/secret decrypt --password ${SECRETS_KEY} --signing
+          ./scripts/play-store/publish-app

--- a/presentation/mobile/build.gradle.kts
+++ b/presentation/mobile/build.gradle.kts
@@ -58,7 +58,11 @@ android {
     }
 
     kotlinOptions.jvmTarget = "1.8"
-    lintOptions.isAbortOnError = false
+    lintOptions {
+        isAbortOnError = false
+        textReport = project.hasProperty("isCI")
+        textOutput("stdout")
+    }
     packagingOptions.exclude("**/*.kotlin_*") // https://youtrack.jetbrains.com/issue/KT-9770
 
     sourceSets.forEach { it.java.srcDir("src/${it.name}/kotlin") }

--- a/scripts/play-store/publish-app
+++ b/scripts/play-store/publish-app
@@ -37,14 +37,14 @@ if [[ ${git_head_commit} == ${git_last_merge_commit} ]] ; then
             approve "Release commit found in branch at ${commit}, publishing app..."
             # Checkout release commit and build exactly that...
             git checkout ${commit}
-            ./gradlew publishReleaseBundle --artifact-dir mobile/build/outputs/bundle/release
+            ./gradlew publish
             git checkout ${git_head_commit}
             exit 0
         fi
     done
 elif is_release_commit ${git_head_commit} ; then
     approve "Release commit found at HEAD (${git_head_commit}), publishing app..."
-    ./gradlew publishReleaseBundle --artifact-dir mobile/build/outputs/bundle/release
+    ./gradlew publish
     exit 0
 fi
 


### PR DESCRIPTION
Enable Android problem matchers [0] and cache the Gradle cache to speed
up the build.

[0] https://github.com/marketplace/actions/android-problem-matchers
[1] https://github.com/actions/cache/blob/master/examples.md#java---gradle