### PR TITLE
Update Kotlin to 1.3.70

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ buildscript {
 plugins {
     id("com.diffplug.gradle.spotless") version "3.27.1"
     id("com.github.ben-manes.versions") version "0.28.0"
-    kotlin("jvm") version "1.3.61"
+    kotlin("jvm") version "1.3.70"
 }
 
 repositories {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.3.61"
+    kotlin("jvm") version "1.3.70"
 }
 
 repositories {

--- a/data/core/build.gradle.kts
+++ b/data/core/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     kotlin("jvm")
-    kotlin("plugin.serialization") version "1.3.61"
+    kotlin("plugin.serialization") version "1.3.70"
 }
 
 repositories {
@@ -8,9 +8,9 @@ repositories {
 }
 
 dependencies {
-    implementation(kotlin("stdlib", "1.3.61"))
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.14.0")
+    implementation(kotlin("stdlib"))
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.20.0")
 
-    testImplementation(kotlin("test-junit", "1.3.61"))
+    testImplementation(kotlin("test-junit"))
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.3")
 }

--- a/data/local/build.gradle.kts
+++ b/data/local/build.gradle.kts
@@ -37,7 +37,7 @@ android {
 dependencies {
     kapt("androidx.room:room-compiler:2.2.4")
 
-    implementation(kotlin("stdlib-jdk8", "1.3.61"))
+    implementation(kotlin("stdlib"))
     implementation(project(":data:core"))
     implementation("androidx.room:room-runtime:2.2.4")
     implementation("androidx.room:room-ktx:2.2.4")

--- a/data/remote/build.gradle.kts
+++ b/data/remote/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     kotlin("jvm")
-    kotlin("plugin.serialization") version "1.3.61"
+    kotlin("plugin.serialization") version "1.3.70"
 }
 
 repositories {
@@ -8,15 +8,15 @@ repositories {
 }
 
 dependencies {
-    implementation(kotlin("stdlib", "1.3.61"))
+    implementation(kotlin("stdlib"))
     implementation(project(":data:core"))
     implementation("io.ktor:ktor-client-android:1.3.1")
     implementation("io.ktor:ktor-client-logging-jvm:1.3.1")
     implementation("io.ktor:ktor-client-serialization-jvm:1.3.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.3")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.14.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.20.0")
 
-    testImplementation(kotlin("test-junit", "1.3.61"))
+    testImplementation(kotlin("test-junit"))
     testImplementation("io.ktor:ktor-client-mock-jvm:1.3.1")
     testImplementation("io.mockk:mockk:1.9.3")
     testRuntimeOnly("ch.qos.logback:logback-classic:1.2.3")

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -21,7 +21,7 @@ android {
 }
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8", "1.3.61"))
+    implementation(kotlin("stdlib"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.3")
     // TODO: Consider domain-specific models to hide underlying layers. Currently, considered overkill.
     api(project(":data:core"))

--- a/presentation/common/build.gradle.kts
+++ b/presentation/common/build.gradle.kts
@@ -28,7 +28,7 @@ android {
 }
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8", "1.3.61"))
+    implementation(kotlin("stdlib-jdk8"))
     implementation("androidx.preference:preference-ktx:1.1.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.3")
 

--- a/presentation/mobile/build.gradle.kts
+++ b/presentation/mobile/build.gradle.kts
@@ -74,7 +74,7 @@ android {
 }
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8", "1.3.61"))
+    implementation(kotlin("stdlib-jdk8"))
     implementation(project(":domain"))
     implementation(project(":presentation:common"))
     implementation("androidx.browser:browser:1.2.0")


### PR DESCRIPTION
See upstream release announcement [0]. KotlinxX.Serialization has to be
updated to 0.20.0 as well for compatibility [1].

[0] https://blog.jetbrains.com/kotlin/2020/03/kotlin-1-3-70-released/
[1] https://github.com/Kotlin/kotlinx.serialization/blob/master/CHANGELOG.md#0200--2020-03-04